### PR TITLE
Add language that allows registry transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
 
         <ul>
           <li>
-            <a href="https://www.w3.org/TR/did-spec-registries/">DID Specification Registries</a>
+            <a href="https://www.w3.org/TR/did-spec-registries/">DID Specification Registries</a>, including transitioning it from a WG Note to a W3C Registry, should such a formal registry be defined by W3C Process and should that process allow such a transition.
           </li>
           <li>
             Decentralized Characteristics Rubric


### PR DESCRIPTION
This PR adds language to clarify that the maintenance group may transition the DID Spec Registries from a WG Note to a W3C Registry according to the as yet unadopted process, should that process allow such a transition.

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>