### PR TITLE
Made the changes agreed on last WG all

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,12 +151,17 @@
             <a href="https://www.w3.org/TR/did-spec-registries/">DID Specification Registries</a>, including transitioning it from a WG Note to a W3C Registry, should such a formal registry be defined by W3C Process and should that process allow such a transition.
           </li>
           <li>
-            <a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a> <i class=todo>(Note: this link is currently 404, the planned publication for this note is mid-August)</i>
+            <a href="https://w3c.github.io/did-rubric/">DID Method Rubric</a>, including transitioning it from a WG Note to a W3C Registry, should such a formal registry be defined by W3C Process and should that process allow such a transition. 
           </li>
           <li>
-            <a href="https://www.w3.org/TR/did-cbor-representation/">The Plain CBOR representation</a>
+            <a href="https://www.w3.org/TR/did-cbor-representation/">The Plain CBOR representation</a>.
+          </li>
+          <li>
+            <a href="https://w3c.github.io/did-imp-guide/">DID Implementation Guide v1.0</a>.
           </li>
         </ul>
+
+        <p class=todo>Note: at the time of writing the Rubric and the Implementation Guide have not yet been published as WG Notes by the current DID WG, hence referring to the editors' drafts only. The publication for these notes should happen before mid-September.</p>
 
         <p>The Working Group may also publish new Working Group Notes that may be necessary to clarify, help the deployment and usage, or propose new features to the Group’s main recommendation-track deliverable.</p>
 
@@ -206,7 +211,7 @@
               <p>
                 Latest publication: <i class=todo>2021-09-@@@@</i>.
                 <br>
-                Reference Draft: <i class=todo>https://www.w3.org/TR/2021/REC-did-core-202109@@@@</i>
+                Reference Document: <i class=todo>https://www.w3.org/TR/2021/REC-did-core-202109@@@@</i>
                 <br>
                 Associated <a href="https://www.w3.org/mid/cfe-8207-eacee75cfbd6cba6f474056c47d26d35b57ca134@w3.org">Call for exclusion</a> started on 2021-06-15, opportunity until 2021-08-14
                 <br>
@@ -227,18 +232,21 @@
               <p>
                 Status: Group Note
                 <br>
-                Last update: <i class=todo>@@@@@</i>
+                Last update: 2021-08-06
               </p>                
               <p>
                 If, during the chartered period of the Working Group, the <a href="https://www.w3.org/Consortium/Process/Drafts/">next version of the W3C Process</a> is adopted, incorporating the concept of a <a href="https://www.w3.org/Consortium/Process/Drafts/#registries">Registry Track</a>, the Working Group will consider publishing the DID Specification Registries as a Registry Track document instead of a Working Group Note.
               </p>
             </dd>
-            <dt><a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a></dt>
+            <dt><a href="https://w3c.github.io/did-rubric/">DID Method Rubric</a></dt>
             <dd>
               <p>
                 Status: Group Note
                 <br>
-                Last update: <i class=todo>@@@@@</i>  
+                Last update: <i class=todo>Not yet published as a formal note by the current WG, should happen by mid September</i>  
+              </p>
+              <p>
+                If, during the chartered period of the Working Group, the <a href="https://www.w3.org/Consortium/Process/Drafts/">next version of the W3C Process</a> is adopted, incorporating the concept of a <a href="https://www.w3.org/Consortium/Process/Drafts/#registries">Registry Track</a>, the Working Group will consider publishing the DID Specification Registries as a Registry Track document instead of a Working Group Note.
               </p>
             </dd>
             <dt><a href="https://www.w3.org/TR/did-cbor-representation/">The Plain CBOR representation</a></dt>
@@ -247,6 +255,14 @@
                 Status: Group Note
                 <br>
                 Last update: 2021-06-29  
+              </p>
+            </dd>
+            <dt><a href="https://w3c.github.io/did-imp-guide/">DID Implementation Guide v1.0</a></dt>
+            <dd>
+              <p>
+                Status: Group Note
+                <br>
+                Last update: <i class=todo>Not yet published as a formal note by the current WG, should happen by mid September</i>  
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
                 Last update: <i class=todo>Not yet published as a formal note by the current WG, should happen by mid September</i>  
               </p>
               <p>
-                If, during the chartered period of the Working Group, the <a href="https://www.w3.org/Consortium/Process/Drafts/">next version of the W3C Process</a> is adopted, incorporating the concept of a <a href="https://www.w3.org/Consortium/Process/Drafts/#registries">Registry Track</a>, the Working Group will consider publishing the DID Specification Registries as a Registry Track document instead of a Working Group Note.
+                If, during the chartered period of the Working Group, the <a href="https://www.w3.org/Consortium/Process/Drafts/">next version of the W3C Process</a> is adopted, incorporating the concept of a <a href="https://www.w3.org/Consortium/Process/Drafts/#registries">Registry Track</a>, the Working Group will consider publishing the DID Method Rubric as a Registry Track document instead of a Working Group Note.
               </p>
             </dd>
             <dt><a href="https://www.w3.org/TR/did-cbor-representation/">The Plain CBOR representation</a></dt>


### PR DESCRIPTION
- Added notes to the Rubric whereby it may transition to a W3C Repository Document
- Added the implementation guide as a to-be-published note. (I know this is still pending, but it can be removed/reformulated if the WG decides not to publish at this round).

See [discussion on last meeting](https://www.w3.org/2019/did-wg/Meetings/Minutes/2021-08-10-did#section3).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-wg-charter/pull/9.html" title="Last updated on Aug 19, 2021, 4:51 AM UTC (9e3df0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-wg-charter/9/db99e78...9e3df0b.html" title="Last updated on Aug 19, 2021, 4:51 AM UTC (9e3df0b)">Diff</a>