### PR TITLE
Minor changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
               Chairs
             </th>
             <td>
-              Brent Zundel (Evernym)
+              Brent Zundel (Evernym), <i class='todo'>T.B.D.</i>
             </td>
           </tr>
           <tr>
@@ -118,7 +118,7 @@
               Team Contact
             </th>
             <td>
-              <a href="mailto:ivan@w3.org">Ivan Herman</a> <i class="todo">(0.05 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+              <i class="todo">T.B.D.</i> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
             </td>
           </tr>
           <tr>
@@ -148,10 +148,10 @@
 
         <ul>
           <li>
-            <a href="https://www.w3.org/TR/did-spec-registries/">DID Specification Registries</a>, including transitioning it from a WG Note to a W3C Registry, should such a formal registry be defined by W3C Process and should that process allow such a transition.
+            <a href="https://www.w3.org/TR/did-spec-registries/">DID Specification Registries</a>, including transitioning it from a WG Note to a <a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry</a>.
           </li>
           <li>
-            <a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a>, including transitioning it from a WG Note to a W3C Registry, should such a formal registry be defined by W3C Process and should that process allow such a transition. 
+            <a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a>, including transitioning it from a WG Note to a <a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry</a>. 
           </li>
           <li>
             <a href="https://www.w3.org/TR/did-cbor-representation/">The Plain CBOR representation</a>.
@@ -207,9 +207,9 @@
             <dt><a href="https://www.w3.org/TR/did-core/">Decentralized Identifiers (DIDs) v1.0</a></dt>
             <dd>
               <p>
-                Latest publication: <i class=todo>2021-09-@@@@</i>.
+                Latest publication: <i class=todo>2022-@@-@@@@</i>.
                 <br>
-                Reference Document: <i class=todo>https://www.w3.org/TR/2021/REC-did-core-202109@@@@</i>
+                Reference Document: <i class=todo>https://www.w3.org/TR/2021/REC-did-core-2022@@@@@@</i>
                 <br>
                 Associated <a href="https://www.w3.org/mid/cfe-8207-eacee75cfbd6cba6f474056c47d26d35b57ca134@w3.org">Call for exclusion</a> started on 2021-06-15, opportunity until 2021-08-14
                 <br>
@@ -230,10 +230,10 @@
               <p>
                 Status: Group Note
                 <br>
-                Last update: 2021-08-19
+                Last update: 2021-11-02
               </p>                
               <p>
-                If, during the chartered period of the Working Group, the <a href="https://www.w3.org/Consortium/Process/Drafts/">next version of the W3C Process</a> is adopted, incorporating the concept of a <a href="https://www.w3.org/Consortium/Process/Drafts/#registries">Registry Track</a>, the Working Group will consider publishing the DID Specification Registries as a Registry Track document instead of a Working Group Note.
+                The Working Group Note will be transitioned to a <a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry</a>.
               </p>
             </dd>
             <dt><a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a></dt>
@@ -241,10 +241,10 @@
               <p>
                 Status: Group Note
                 <br>
-                Last update: 2021-08-26  
+                Last update: 2021-11-19  
               </p>
               <p>
-                If, during the chartered period of the Working Group, the <a href="https://www.w3.org/Consortium/Process/Drafts/">next version of the W3C Process</a> is adopted, incorporating the concept of a <a href="https://www.w3.org/Consortium/Process/Drafts/#registries">Registry Track</a>, the Working Group will consider publishing the DID Method Rubric as a Registry Track document instead of a Working Group Note.
+                The Working Group Note will be transitioned to a <a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry</a>.
               </p>
             </dd>
             <dt><a href="https://www.w3.org/TR/did-cbor-representation/">The Plain CBOR representation</a></dt>
@@ -260,7 +260,7 @@
               <p>
                 Status: Group Note
                 <br>
-                Last update: 2021-08-26  
+                Last update: 2021-10-12  
               </p>
             </dd>
           </dl>


### PR DESCRIPTION
- The header has changed (signalling the possibility for a co-chair, the staff contact's name T.B.D., etc)
- The conditionality of a transition to a W3C registry removed (now that we are in the new process era)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-wg-charter/pull/18.html" title="Last updated on Dec 15, 2021, 8:02 AM UTC (b066377)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-wg-charter/18/17e9a1f...b066377.html" title="Last updated on Dec 15, 2021, 8:02 AM UTC (b066377)">Diff</a>