### PR TITLE
Add DID Method Specifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
       <p class="mission">
 The <strong>mission</strong> of the
 <a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a>
-is to maintain the <a href="https://www.w3.org/TR/did-core/">DID Identifiers</a>
+is to maintain the <a href="https://www.w3.org/TR/did-core/">Decentralized Identifiers (DIDs)</a>
 specification and related Working Group Notes. The WG will also seek consensus
 around the specification of DID Methods.
       </p>

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@ level changes on the Recommendation.
         </p>
         <p>
 The Working Group will also seek consensus around DID Method specifications, and
-may produce related Working Group Notes.
+may produce related documents.
         </p>
       </section>
 
@@ -176,6 +176,11 @@ may produce related Working Group Notes.
         </ul>
 
         <p>The Working Group may also publish new Working Group Notes that may be necessary to clarify, help the deployment and usage, or propose new features to the Group’s main recommendation-track deliverable.</p>
+        <p>
+The Working Group may also publish new Working Group Notes, Editors Drafts, or
+Working Drafts of DID Method Specifications. Any documents intended for
+Recommendation will be limited to the Working Draft maturity level.
+        </p>
 
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ around the specification of DID Methods.
               Chairs
             </th>
             <td>
-              Brent Zundel (Evernym), <i class='todo'>T.B.D.</i>
+              Brent Zundel (Avast), <i class='todo'>T.B.D.</i>
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,13 @@
       <h1 id="title"><i class="todo">PROPOSED</i> Decentralized Identifier Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a> is to maintain the <a href="https://www.w3.org/TR/did-core/">DID Identifiers</a> specification and related Working Group Notes.</p>
+      <p class="mission">
+The <strong>mission</strong> of the
+<a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a>
+is to maintain the <a href="https://www.w3.org/TR/did-core/">DID Identifiers</a>
+specification and related Working Group Notes. The WG will also seek consensus
+around the specification of DID Methods.
+      </p>
 
       <div class="noprint">
         <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/117488/join">Join the Decentralized Identifier Working Group.</a></p>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,15 @@ around the specification of DID Methods.
 
       <section id="background" class="background">
         <p>
-          The Working Group will maintain the <a href="https://www.w3.org/TR/did-core/">DID</a> specification, which defines a new type of identifier that enables verifiable, decentralized digital identity. This includes possible <a href="https://www.w3.org/2020/Process-20200915/#correction-classes">class 1, 2, or 3 </a> level changes on the Recommendation.
+The Working Group will maintain the <a href="https://www.w3.org/TR/did-core/">DID</a>
+specification, which defines a new type of identifier that enables verifiable,
+decentralized digital identity. This includes possible
+<a href="https://www.w3.org/2020/Process-20200915/#correction-classes">class 1, 2, or 3 </a>
+level changes on the Recommendation.
+        </p>
+        <p>
+The Working Group will also seek consensus around DID Method specifications, and
+may produce related Working Group Notes.
         </p>
       </section>
 


### PR DESCRIPTION
This PR adds mention of DID Method Specifications to the mission and scope of the charter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/did-wg-charter/pull/20.html" title="Last updated on Aug 19, 2022, 12:04 PM UTC (840bd29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-wg-charter/20/63c2c27...brentzundel:840bd29.html" title="Last updated on Aug 19, 2022, 12:04 PM UTC (840bd29)">Diff</a>