### PR TITLE
Remove mention of DID Methods from the charter

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@ intended for Recommendation will be limited to the Working Draft maturity level.
              This document specifies the algorithms and guidelines for resolving DIDs and dereferencing DID URLs.
              </p>
              <p class="draft-status">
-             The <a href="https://w3c-ccg.github.io/did-resolution/">Draft Community Group Report</a>
+             The <a href="https://w3c-ccg.github.io/did-resolution/">Draft Community Group Report</a> may serve as a starting point.
              </p>
              <p>
              It is not intended that DID Resolution and DID URL Dereferencing will advance beyond <a href="https://www.w3.org/2021/Process-20211102/#RecsWD">Working Draft status</a>.

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ specification and related Working Group Notes. The WG will also seek consensus a
               Chairs
             </th>
             <td>
-              TBD
+              Brent Zundel (Gen), <i class='todo'>T.B.D.</i>
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@ and DID URL Dereferencing.
         <p>
 The Working Group may also publish new Working Group Notes, Editors Drafts, or
 Working Drafts for DID Resolution or DID URL Dereferencing, or of DID Method
-Specifications. Any of these documents intended for Recommendation will be
+Specifications. Any new documents intended for Recommendation will be
 limited to the Working Draft maturity level.
         </p>
 
@@ -242,18 +242,30 @@ limited to the Working Draft maturity level.
           </p>
 
           <dl>
-            <dt ><a href="https://www.w3.org/TR/did-core/">Decentralized Identifiers (DIDs) v1.0</a></dt>
-            <dd>
-              <p>
-                Latest publication: <i>2022-07-19</i>.
-                <br>
-                Reference Document: <a href="https://www.w3.org/TR/2022/REC-did-core-20220719/">https://www.w3.org/TR/2022/REC-did-core-20220719/</a>
-                <br>
-                Associated <a href="https://www.w3.org/mid/cfe-8207-eacee75cfbd6cba6f474056c47d26d35b57ca134@w3.org">Call for exclusion</a> started on 2021-06-15, opportunity until 2021-08-14
-                <br>
-                Produced under Working Group Charter: <a href="https://www.w3.org/2020/12/did-wg-charter.html">https://www.w3.org/2020/12/did-wg-charter.html</a>.
-              </p>
-            </dd>
+            <dt >Decentralized Identifier (DID) Method Specification</dt>
+           <dd>
+             <p>
+             DID Method Specifications may be produced by the working group.
+             </p>
+             <p>
+             The <a href="https://www.w3.org/TR/did-spec-registries/#did-methods">DID Specification Registries</a> contains many links to examples of DID Method Specifications, some of which may be selected by the working group for development into a Recommendation. The group might also choose a similar starting document not listed in the Registry.
+             </p>
+             <p>
+             It is not intended that any DID Method Specification adopted by the working group will advance beyond <a href="https://www.w3.org/2021/Process-20211102/#RecsWD">Working Draft status</a>.
+             </p>
+           </dd>
+            <dt >Decentralized Identifier (DID) Resolution and DID URL Dereferencing v1.0</dt>
+           <dd>
+             <p>
+             This document specifies the algorithms and guidelines for resolving DIDs and dereferencing DID URLs.
+             </p>
+             <p class="draft-status">
+             The <a href="https://w3c-ccg.github.io/did-resolution/">Draft Community Group Report</a>
+             </p>
+             <p>
+             It is not intended that DID Resolution and DID URL Dereferencing will advance beyond <a href="https://www.w3.org/2021/Process-20211102/#RecsWD">Working Draft status</a>.
+             </p>
+           </dd>
           </dl>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -183,8 +183,8 @@ and DID URL Dereferencing.
         <p>
 The Working Group may also publish new Working Group Notes, Editors Drafts, or
 Working Drafts for DID Resolution or DID URL Dereferencing, or of DID Method
-Specifications. Any documents intended for Recommendation will be limited to the
-Working Draft maturity level.
+Specifications. Any of these documents intended for Recommendation will be
+limited to the Working Draft maturity level.
         </p>
 
         <section id="section-out-of-scope">
@@ -234,6 +234,24 @@ Working Draft maturity level.
                 Associated <a href="https://www.w3.org/mid/cfe-8207-eacee75cfbd6cba6f474056c47d26d35b57ca134@w3.org">Call for exclusion</a> started on 2021-06-15, opportunity until 2021-08-14
                 <br>
                 Produced under Working Group Charter: <a href="https://www.w3.org/2020/12/did-wg-charter.html">https://www.w3.org/2020/12/did-wg-charter.html</a>.  
+              </p>
+            </dd>
+          </dl>
+          <p>
+            The Working Group may begin work on the following W3C normative specifications:
+          </p>
+
+          <dl>
+            <dt ><a href="https://www.w3.org/TR/did-core/">Decentralized Identifiers (DIDs) v1.0</a></dt>
+            <dd>
+              <p>
+                Latest publication: <i>2022-07-19</i>.
+                <br>
+                Reference Document: <a href="https://www.w3.org/TR/2022/REC-did-core-20220719/">https://www.w3.org/TR/2022/REC-did-core-20220719/</a>
+                <br>
+                Associated <a href="https://www.w3.org/mid/cfe-8207-eacee75cfbd6cba6f474056c47d26d35b57ca134@w3.org">Call for exclusion</a> started on 2021-06-15, opportunity until 2021-08-14
+                <br>
+                Produced under Working Group Charter: <a href="https://www.w3.org/2020/12/did-wg-charter.html">https://www.w3.org/2020/12/did-wg-charter.html</a>.
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -79,8 +79,7 @@
 The <strong>mission</strong> of the
 <a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a>
 is to maintain the <a href="https://www.w3.org/TR/did-core/">Decentralized Identifiers (DIDs)</a>
-specification and related Working Group Notes. The WG will also seek consensus
-around the specification of DID Methods and DID Resolution.
+specification and related Working Group Notes. The WG will also seek consensus around the best way to achieve effective interoperability.
       </p>
 
       <div class="noprint">
@@ -116,7 +115,7 @@ around the specification of DID Methods and DID Resolution.
               Chairs
             </th>
             <td>
-              Brent Zundel (Avast), <i class='todo'>T.B.D.</i>
+              TBD
             </td>
           </tr>
           <tr>
@@ -149,10 +148,6 @@ decentralized digital identity. This includes possible
 level changes on the Recommendation.
         </p>
         <p>
-The Working Group will also seek consensus around DID Method specifications, and
-may produce related documents.
-        </p>
-        <p>
 The Working Group will begin working toward a specification for DID Resolution
 and DID URL Dereferencing.
         </p>
@@ -182,9 +177,8 @@ and DID URL Dereferencing.
         <p>The Working Group may also publish new Working Group Notes that may be necessary to clarify, help the deployment and usage, or propose new features to the Group’s main recommendation-track deliverable.</p>
         <p>
 The Working Group may also publish new Working Group Notes, Editors Drafts, or
-Working Drafts for DID Resolution or DID URL Dereferencing, or of DID Method
-Specifications. Any new documents intended for Recommendation will be
-limited to the Working Draft maturity level.
+Working Drafts for DID Resolution or DID URL Dereferencing. Any new documents
+intended for Recommendation will be limited to the Working Draft maturity level.
         </p>
 
         <section id="section-out-of-scope">
@@ -242,18 +236,6 @@ limited to the Working Draft maturity level.
           </p>
 
           <dl>
-            <dt >Decentralized Identifier (DID) Method Specification</dt>
-           <dd>
-             <p>
-             DID Method Specifications may be produced by the working group.
-             </p>
-             <p>
-             The <a href="https://www.w3.org/TR/did-spec-registries/#did-methods">DID Specification Registries</a> contains many links to examples of DID Method Specifications, some of which may be selected by the working group for development into a Recommendation. The group might also choose a similar starting document not listed in the Registry.
-             </p>
-             <p>
-             It is not intended that any DID Method Specification adopted by the working group will advance beyond <a href="https://www.w3.org/2021/Process-20211102/#RecsWD">Working Draft status</a>.
-             </p>
-           </dd>
             <dt >Decentralized Identifier (DID) Resolution and DID URL Dereferencing v1.0</dt>
            <dd>
              <p>


### PR DESCRIPTION
Remove mention of DID Method specification text from the charter and add deliverables for DID Resolution and DID Dereferencing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/did-wg-charter/pull/29.html" title="Last updated on Jan 25, 2023, 5:06 PM UTC (f91e71f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-wg-charter/29/2245211...brentzundel:f91e71f.html" title="Last updated on Jan 25, 2023, 5:06 PM UTC (f91e71f)">Diff</a>