### PR TITLE
Align to latest template

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@ limited to the Working Draft maturity level.
 	  <h2>Success Criteria</h2>
     <!-- Testing and interop -->
 	  <p>In order to advance to 
-		  <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have 
+		  <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a> or to <a href="https://www.w3.org/2023/Process-20230612/#change-review">incorporate candidate amendments</a>, each normative specification is expected to have 
 		  <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent interoperable
 			  implementations</a> of every feature defined in the specification, where
 interoperability can be verified by passing open test suites, and two or

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
       }
     </style>
   </head>
-  <body>
+  <body cz-shortcut-listen="true">
     <header id="header">
       <aside>
         <ul id="navbar">
@@ -142,6 +142,7 @@ specification of DID Resolution and/or DID methods.
       </section>
 
       <section id="background" class="background">
+        <h2>Motivation and Background</h2>
         <p>
 The Working Group will maintain the <a href="https://www.w3.org/TR/did-core/">DID</a>
 specification, which defines a new type of identifier that enables verifiable,
@@ -321,11 +322,35 @@ limited to the Working Draft maturity level.
 
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
-	  <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
-
-	  <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
-
+    <!-- Testing and interop -->
+	  <p>In order to advance to 
+		  <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have 
+		  <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent interoperable
+			  implementations</a> of every feature defined in the specification, where
+interoperability can be verified by passing open test suites, and two or
+more implementations interoperating with each other. In order to advance to
+Proposed Recommendation, each normative specification must have an open
+test suite of every feature defined in the specification.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+
+    <!-- Horizontal review -->
+
+    <p>Each specification should contain sections detailing 
+    security and privacy implications for implementers, 
+    Web authors, and end users, 
+    as well as recommendations for mitigations.
+    There should be a clear description of the residual risk 
+    to the user or operator of that protocol 
+    after threat mitigation has been deployed.</p>
+
+    <!-- Design principles -->
+    <p>This Working Group expects to follow the
+    TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.
+    </p>
+	
+    <!-- Relevance and momentum -->
+	  <p>All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>
+
 	</section>
 
       <section id="coordination">
@@ -452,7 +477,7 @@ limited to the Working Draft maturity level.
           Decision Policy
         </h2>
         <p>
-          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 5.2.1, Consensus</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
         <p>
            However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
         </p>
@@ -467,7 +492,7 @@ limited to the Working Draft maturity level.
           All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
         </p>
         <p>
-          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 3.4, Votes)</a> and includes no voting procedures beyond what the Process Document requires.
+          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
         </p>
       </section>
 
@@ -480,7 +505,7 @@ limited to the Working Draft maturity level.
         <p>
           This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
 
-          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/did/ipr">licensing information</a>.
         </p>
 
       </section>
@@ -499,7 +524,7 @@ limited to the Working Draft maturity level.
           About this Charter
         </h2>
         <p>
-          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#WG-and-IG">section 5.2</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
         </p>
 
         <section id="history">
@@ -507,7 +532,7 @@ limited to the Working Draft maturity level.
             Charter History
           </h3>
 
-          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
 
           <table class="history">
             <tbody>
@@ -615,19 +640,11 @@ limited to the Working Draft maturity level.
         <i class="todo"><a href="mailto:pierre-antoine@w3.org">Pierre-Antoine Champin</a></i>
       </address>
 
-      <p class="copyright">
-        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©2021
-        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
-        (
-        <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="https://www.keio.ac.jp/">Keio</a>,
-        <a href="https://ev.buaa.edu.cn/">Beihang</a>
-        ), All Rights Reserved.
-
-        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
-      </p>
-      <hr>
+      <p class="copyright">Copyright © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+        <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+            <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.</p>      <hr>
       <p><a href="https://github.com/w3c/did-wg-charter">Yes, it's on GitHub!</a>.</p>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
       }
     </style>
   </head>
-  <body cz-shortcut-listen="true">
+  <body>
     <header id="header">
       <aside>
         <ul id="navbar">
@@ -225,16 +225,19 @@ limited to the Working Draft maturity level.
           </p>
 
           <dl>
-            <dt><a href="https://www.w3.org/TR/did-core/">Decentralized Identifiers (DIDs) v1.0</a></dt>
+            <dt class="spec"><a href="https://www.w3.org/TR/did-core/">Decentralized Identifiers (DIDs) v1.0</a></dt>
             <dd>
-              <p>
-                Latest publication: <i>2022-07-19</i>.
-                <br>
-                Reference Document: <a href="https://www.w3.org/TR/2022/REC-did-core-20220719/">https://www.w3.org/TR/2022/REC-did-core-20220719/</a>
-                <br>
-                Associated <a href="https://www.w3.org/mid/cfe-8207-eacee75cfbd6cba6f474056c47d26d35b57ca134@w3.org">Call for exclusion</a> started on 2021-06-15, opportunity until 2021-08-14
-                <br>
-                Produced under Working Group Charter: <a href="https://www.w3.org/2020/12/did-wg-charter.html">https://www.w3.org/2020/12/did-wg-charter.html</a>.  
+              <p>This specification defines new type of identifier that enables verifiable, decentralized digital identity.
+              </p><p class="draft-status">
+                  <b>Draft State</b>: Recommendation
+              </p><p class="milestone">
+                  <b>Expected completion</b>: not applicable (maintenance)
+              </p><p>
+                  <b>Adpoted Draft</b>: Decentralized Identifiers (DIDs) v1.0, <a href="https://www.w3.org/TR/2022/REC-did-core-20220719/">https://www.w3.org/TR/2022/REC-did-core-20220719/</a>, published 2022-07-19
+              </p><p>
+                  <b>Exclusion Draft</b>: Decentralized Identifiers (DIDs) v1.0, <a href="https://www.w3.org/TR/2021/CR-did-core-20210615/">https://www.w3.org/TR/2021/CR-did-core-20210615/</a>, published 2021-06-15. Exclusion period <b>began</b> 2021-06-15, <b>ended</b> 2021-08-14.
+              </p><p>
+                  <b>Exclusion Draft Charter</b>: <a href="https://www.w3.org/2020/12/did-wg-charter.html">https://www.w3.org/2020/12/did-wg-charter.html</a>.  
               </p>
             </dd>
           </dl>
@@ -243,28 +246,31 @@ limited to the Working Draft maturity level.
           </p>
 
           <dl>
-            <dt >Decentralized Identifier (DID) Method Specification</dt>
+            <dt class="spec">Decentralized Identifier (DID) Method Specification</dt>
            <dd>
              <p>
              DID Method Specifications may be produced by the working group.
              </p>
-             <p>
-             The <a href="https://www.w3.org/TR/did-spec-registries/#did-methods">DID Specification Registries</a> contains many links to examples of DID Method Specifications, some of which may be selected by the working group for development into a Recommendation. The group might also choose a similar starting document not listed in the Registry.
+             <p class="milestone">
+              <b>Expected Completion:</b> It is not intended that any DID Method Specification developed by the working group will advance beyond <a href="https://www.w3.org/Consortium/Process/#RecsWD">Working Draft status</a>.
              </p>
              <p>
-             It is not intended that any DID Method Specification developed by the working group will advance beyond <a href="https://www.w3.org/Consortium/Process/#RecsWD">Working Draft status</a>.
+             <b>Adopted Draft:</b> The <a href="https://www.w3.org/TR/did-spec-registries/#did-methods">DID Specification Registries</a> contains many links to examples of DID Method Specifications, some of which may be selected by the working group for development into a Recommendation. The group might also choose a similar starting document not listed in the Registry.
              </p>
            </dd>
-            <dt >Decentralized Identifier (DID) Resolution and DID URL Dereferencing v1.0</dt>
+            <dt class="spec">Decentralized Identifier (DID) Resolution and DID URL Dereferencing v1.0</dt>
            <dd>
              <p>
              This document specifies the algorithms and guidelines for resolving DIDs and dereferencing DID URLs.
              </p>
              <p class="draft-status">
-             The <a href="https://w3c-ccg.github.io/did-resolution/">DID Resolution v0.3</a> Draft Community Group Report may serve as a starting point.
+              <b>Draft State:</b> Draft Community Group Report
              </p>
-             <p>
+             <p class="milestone"><b>Expected completion:</b>
              It is not intended that DID Resolution and DID URL Dereferencing will advance beyond <a href="https://www.w3.org/Consortium/Process/#RecsWD">Working Draft status</a>.
+             </p>
+             <p><b>Adopted Draft:</b>
+              DID Resolution v0.3, <a href="https://w3c-ccg.github.io/did-resolution/">https://w3c-ccg.github.io/did-resolution/</a>, published 2023-01-18, may serve as a starting point.
              </p>
            </dd>
           </dl>
@@ -276,7 +282,7 @@ limited to the Working Draft maturity level.
           </h3>
 
           <dl>
-            <dt><a href="https://www.w3.org/TR/did-spec-registries/">DID Specification Registries</a></dt>
+            <dt class="spec"><a href="https://www.w3.org/TR/did-spec-registries/">DID Specification Registries</a></dt>
             <dd>
               <p>
                 Status: Group Note
@@ -287,7 +293,7 @@ limited to the Working Draft maturity level.
                 The Working Group Note will be transitioned to a <a href="https://www.w3.org/Consortium/Process/#registries">W3C Registry</a>.
               </p>
             </dd>
-            <dt><a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a></dt>
+            <dt class="spec"><a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a></dt>
             <dd>
               <p>
                 Status: Group Note
@@ -298,7 +304,7 @@ limited to the Working Draft maturity level.
                 The Working Group Note will be transitioned to a <a href="https://www.w3.org/Consortium/Process/#registries">W3C Registry</a>.
               </p>
             </dd>
-            <dt><a href="https://www.w3.org/TR/did-cbor-representation/">The Plain CBOR representation</a></dt>
+            <dt class="spec"><a href="https://www.w3.org/TR/did-cbor-representation/">The Plain CBOR representation</a></dt>
             <dd>
               <p>
                 Status: Group Note
@@ -306,7 +312,7 @@ limited to the Working Draft maturity level.
                 Last update: 2021-06-26  
               </p>
             </dd>
-            <dt><a href="https://www.w3.org/TR/did-imp-guide/">DID Implementation Guide v1.0</a></dt>
+            <dt class="spec"><a href="https://www.w3.org/TR/did-imp-guide/">DID Implementation Guide v1.0</a></dt>
             <dd>
               <p>
                 Status: Group Note

--- a/index.html
+++ b/index.html
@@ -339,6 +339,12 @@ Proposed Recommendation, each normative specification must have an open
 test suite of every feature defined in the specification.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 
+    <p>To promote interoperability, all changes made to specifications
+      in Candidate Recommendation
+      or to features that have deployed implementations
+      should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.
+      Testing efforts should be conducted via the <a href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a> project.</p>
+
     <!-- Horizontal review -->
 
     <p>Each specification should contain sections detailing 
@@ -513,7 +519,6 @@ test suite of every feature defined in the specification.</p>
 
           For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/did/ipr">licensing information</a>.
         </p>
-
       </section>
 
 


### PR DESCRIPTION
responding to W3M/TiLT comments, this PR aligns the charter proposal to the latest charter template.

All the new content is some boilerplate (with minor adaptations) from the template.

All other changes are essentially editorials: the information has been reorganized in a way that matches the template better, but not substansively modified.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-wg-charter/pull/34.html" title="Last updated on Jul 21, 2023, 7:31 PM UTC (c6b7778)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-wg-charter/34/fbeb573...c6b7778.html" title="Last updated on Jul 21, 2023, 7:31 PM UTC (c6b7778)">Diff</a>